### PR TITLE
Fix Garry's Mod RCON Support

### DIFF
--- a/hlsw/cfg/Games.cfg
+++ b/hlsw/cfg/Games.cfg
@@ -2642,10 +2642,6 @@
 				['Name'] = 'Project Cars';
 				['IconName'] = 'GameType_RZA';
 			};
-			['base'] = {
-				['Name'] = 'Reflex';
-				['IconName'] = 'GameType_R';
-			};
 			['donotstarvetogether'] = {
 				['Name'] = 'Dont Starve Together';
 				['IconName'] = 'GameType_DST';
@@ -2670,6 +2666,18 @@
 				['Name'] = 'Conan Exiles';
 				['IconName'] = 'GameType_CONAN';
 			};
+			['garrysmod'] = {
+				['Name'] = "Garry's Mod";
+				//['Acronym'] = 'GMod';
+				['URL'] = 'https://hlswfixes.com/Garrys_Mod';
+				['ModVersion'] = '13';
+
+				['IconName'] = 'GameType_HL2_GM';
+			};
+//			['base'] = {
+//				['Name'] = 'Reflex';
+//				['IconName'] = 'GameType_R';
+//			};
 //			['irongrip'] = {
 //				['Name'] = 'Iron Grip: The Oppression';
 //				['URL'] = 'https://hlswfixes.com/Iron_Grip:_The_Oppression';
@@ -2696,14 +2704,6 @@
 //			['fsx'] = {
 //				['Name'] = 'Microsoft Flight Simulator X';
 //				['IconName'] = 'GameType_FSX';
-//			};
-//			['gmod9'] = {
-//				['Name'] = "Garry's Mod";
-//				//['Acronym'] = 'GMod';
-//				['URL'] = 'https://hlswfixes.com/Garrys_Mod';
-//				['ModVersion'] = '9';
-//
-//				['IconName'] = 'GameType_HL2_GM';
 //			};
 //			['miscreated'] = {
 //				['Name'] = 'Miscreated';
@@ -6314,21 +6314,21 @@
 		};
 		['IconName'] = 'GameType_CoDMW3';
 	};
-	['_Custom:Garrys Mod'] = {
-		['Name'] = 'Garrys Mod';
-		['URL'] = 'https://steamdb.info/app/4000';
-		['SupportedSince'] = 'v1.4.0.5';
-		['SteamId'] = 4000;
-		['Query'] = {
-			['Protocol'] = {
-				[0] = {
-					['Protocol'] = 'HL2';
-					['Condition'] = 'None';
-				};
-			};
-		};
-		['IconName'] = 'GameType_HL2_GM';
-	};
+//	['_Custom:Garrys Mod'] = {
+//		['Name'] = 'Garrys Mod';
+//		['URL'] = 'https://steamdb.info/app/4000';
+//		['SupportedSince'] = 'v1.4.0.5';
+//		['SteamId'] = 4000;
+//		['Query'] = {
+//			['Protocol'] = {
+//				[0] = {
+//					['Protocol'] = 'HL2';
+//					['Condition'] = 'None';
+//				};
+//			};
+//		};
+//		['IconName'] = 'GameType_HL2_GM';
+//	};
 	['_Custom:Day of Defeat: Source'] = {
 		['Name'] = 'Day of Defeat: Source';
 		['URL'] = 'https://hlswfixes.com/Day_of_Defeat';

--- a/hlsw/cfg/Query.cfg
+++ b/hlsw/cfg/Query.cfg
@@ -563,12 +563,6 @@
 			['ChangeDir']['modernwarfare3'] = '';
 		};
 		[] = {
-			['SteamAppIds'] = "4000";
-			['Game'] = 'Garrys Mod';
-
-			['ChangeDir']['garrysmod'] = '';
-		};
-		[] = {
 			['SteamAppIds'] = "33930";
 			['Game'] = 'Arma 2: Operation Arrowhead';
 


### PR DESCRIPTION
With the current implementation of Garry's Mod with the fixes, you cannot use RCON as it returns a "RCON not supported" error. Implementing it as an HL2 mod again fixes this.